### PR TITLE
fix: add plugin install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ A Snyk Netlify build plugin to add to your Netlify website's pipeline and guard 
 How to add security controls to your website build pipeline in 3 easy steps?
 
 1. **Add the plugin!**
+
    Add the plugin to your project's dependencies:
 
    ```

--- a/README.md
+++ b/README.md
@@ -25,6 +25,11 @@ A Snyk Netlify build plugin to add to your Netlify website's pipeline and guard 
 How to add security controls to your website build pipeline in 3 easy steps?
 
 1. **Add the plugin!**
+   Add the plugin to your project's dependencies:
+
+   ```
+   npm install netlify-plugin-snyk --save-dev
+   ```
 
    If you're using Netlify's UI, browse the _Plugins_ directory and add `netlify-plugin-snyk` to your website project. Or you can also declare the plugin via a `netlify.yoml` configuration file as follows:
 
@@ -34,7 +39,7 @@ How to add security controls to your website build pipeline in 3 easy steps?
    package = "netlify-plugin-snyk"
    ```
 
-2) **Configure the Snyk API token**
+2. **Configure the Snyk API token**
 
    If you alreay have the Snyk CLI installed you can get the token via `snyk config get api` and add an entry in Netlify's [Environment variable settings page](https://app.netlify.com/sites/speak-easy/settings/deploys#environment) with variable name `SNYK_TOKEN`.
 

--- a/README.md
+++ b/README.md
@@ -26,13 +26,15 @@ How to add security controls to your website build pipeline in 3 easy steps?
 
 1. **Add the plugin!**
 
-   Add the plugin to your project's dependencies:
+   If you're using Netlify's UI, browse the _Plugins_ directory and add `netlify-plugin-snyk` to your website project.
+   
+   Otherwise, if you use Netlify's configuration then add the plugin to your project's dependencies:
 
    ```
    npm install netlify-plugin-snyk --save-dev
    ```
 
-   If you're using Netlify's UI, browse the _Plugins_ directory and add `netlify-plugin-snyk` to your website project. Or you can also declare the plugin via a `netlify.yoml` configuration file as follows:
+   and then declare the plugin via a `netlify.yoml` configuration file as follows:
 
    ```
    # netlify.toml


### PR DESCRIPTION
Fixes #1 
Documentation misses instruction on installing the plugin 