### PR TITLE
fix: add netlify manifest.yml file to package

### DIFF
--- a/package.json
+++ b/package.json
@@ -217,6 +217,7 @@
     "@semantic-release/github"
   ],
   "files": [
-    "src"
+    "src",
+    "manifest.yml"
   ]
 }


### PR DESCRIPTION
Fixes #2 
Published package was missing Netlify's `manifest.yml` file