### PR TITLE
feat: enable support for yarn workspaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ To obtain a Snyk API token visit your [Snyk account page](https://app.snyk.io/ac
 
 ## Plugin inputs
 
-The plugin can be configured via a `plugis.inputs` section on the `netlify.toml` file. For example:
+The plugin can be configured via a `plugins.inputs` section on the `netlify.toml` file. For example:
 
 ```
 [[plugins]]
@@ -69,13 +69,15 @@ The plugin can be configured via a `plugis.inputs` section on the `netlify.toml`
 
   [plugins.inputs]
     failOnPreviews = true
+    yarnWorkspaces = false
 ```
 
 Available plugin configuration via inputs:
 
-| name             | description                                                                                      | default                                                                       |
-| ---------------- | ------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------- |
-| `failOnPreviews` | Set this to false if you want to allow deploy previews to pass with a failed Snyk security scan. | `true` and it means deploy previews will fail if Snyk detects security issues |
+| name             | description                                                                                        | default                                                                       |
+| ---------------- | -------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
+| `failOnPreviews` | Set this to false if you want to allow deploy previews to pass with a failed Snyk security scan.   | `true` and it means deploy previews will fail if Snyk detects security issues |
+| `yarnWorkspaces` | If your repository uses Yarn Workspaces set this to `true` which adds the `--yarn-workspaces` flag | `false`                                                                       |
 
 Future configuration options to be added:
 

--- a/__tests__/__fixtures__/fixture-error-no-deps/package.json
+++ b/__tests__/__fixtures__/fixture-error-no-deps/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "fixture-vulns-found",
+  "name": "fixture-error-no-deps",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,10 +1,10 @@
 name: netlify-plugin-snyk
 inputs:
-  - name: severity
-    required: false
-    description: Set to one of `low`, `medium`, or `high` to only fail on a specific threshold of vulnerabilities. Default is `low` and means all vulnerabilities will fail the build.
-    default: low
   - name: failOnPreviews
     required: false
     description: Set this to false if you want to allow deploy previews to pass with a failed Snyk security scan. Default is `true` and means deploy previews will fail if Snyk detects security issues.
     default: true
+  - name: yarnWorkspaces
+    required: false
+    description: If your repository uses Yarn Workspaces set this to `true` which adds the `--yarn-workspaces` flag
+    default: false

--- a/src/Audit.js
+++ b/src/Audit.js
@@ -14,7 +14,7 @@ const ERROR_UNAUTHENTICATED = 2
 const JSON_BUFFER_SIZE = 50 * 1024 * 1024
 
 class Audit {
-  async test({ directory }) {
+  async test({ directory, inputs = {} }) {
     const SNYK_TOKEN = process.env.SNYK_TOKEN
     const shellEnvVariables = Object.assign({}, process.env, {
       SNYK_TOKEN,
@@ -23,7 +23,11 @@ class Audit {
     })
 
     const ExecFile = Util.promisify(ChildProcess.execFile)
-    const args = [...auditCliArgs, ...(directory ? [directory] : [])]
+    const args = [
+      ...auditCliArgs,
+      ...(directory ? [directory] : []),
+      ...(inputs.yarnWorkspaces ? ['--yarn-workspaces'] : [])
+    ]
     let testResults
     try {
       // allow for 50MB of buffer for a large JSON output

--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,7 @@ module.exports = {
     let testResults
     let vulnerabilitiesFound = false
     try {
-      testResults = await audit.test({ directory: projectDirectory })
+      testResults = await audit.test({ directory: projectDirectory, inputs })
       vulnerabilitiesFound = true
     } catch (error) {
       return utils.build.failBuild(error.message)


### PR DESCRIPTION
# Enable support for Yarn Workspaces

Currently the plugin executes the command `npx snyk test` but this fails when a repo is using Yarn Workspaces. This adds support for an input `yarnWorkspaces` to be set which will run the command with the `--yarn-workspaces` cli flag.

![Gromit knitting with yarn](https://media.giphy.com/media/3oEhmHmWP3Y9wQxoli/giphy.gif)

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Related Issue

https://github.com/snyk-labs/netlify-plugin-snyk/issues/7

## Motivation and Context

Running with a repo that implements Yarn Workspaces fails. It would be good to support this.

## How Has This Been Tested?

- [x] Code has been unit tested
- [x] Completed code has been required locally and run using `netlify build` command
- [x] Plugin has be run on Netlify

## Checklist:

- [x] I have updated the documentation (if required).
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I added a picture of a cute animal cause it's fun
